### PR TITLE
Ignore CI workflow for ballerina bot version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - "automated/dependency_version_update"
+      - "automated/dependency_version_update_tmp"
 
 jobs:
     build:


### PR DESCRIPTION
## Purpose
Since the github workflows are triggered on push and on pull request, when the ballerina bot tries to update ballerina lang version, both workflows are run concurrently and test cases fail.

So, CI workflow triggered on `push` will be ignored for ballerina bot after merging this PR. 
Still the PR workflow will run.

## Related PR
We already did this change in other connector repos
Ex: https://github.com/ballerina-platform/module-ballerinax-github/pull/127

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3
