### PR TITLE
Add http client config as another paramter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ java-wrapper/build/**
 
 #Ignore docker caches
 .ballerina
+
+# Ignore gradle build output directory
+build

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.twitter
-version=1.0.1-SNAPSHOT
+version=2.0.0
 ballerinaLangVersion=2.0.0-beta.3
-

--- a/twitter/Ballerina.toml
+++ b/twitter/Ballerina.toml
@@ -12,7 +12,7 @@ keywords = ["Marketing/Social Media Accounts", "Cost/Freemium"]
 observability-included=true
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-1.0.1-SNAPSHOT.jar"
+path = "../java-wrapper/build/libs/java-wrapper-2.0.0.jar"
 groupId = "org.ballerinalang.twitter"
 artifactId = "java-wrapper"
-version = "1.0.1-SNAPSHOT"
+version = "2.0.0"

--- a/twitter/endpoint.bal
+++ b/twitter/endpoint.bal
@@ -41,10 +41,11 @@ public isolated client class  Client {
     # Create a [Twitter Developer Account](https://developer.twitter.com/en/apply-for-access) and obtain credentials following [this guide](https://developer.twitter.com/en/docs/authentication/oauth-1-0a). 
     #
     # + twitterConfig - Configuration for the connector
+    # + httpConfig - HTTP configuration
     # + return - `http:Error` in case of failure to initialize or `null` if successfully initialized 
-    public isolated function init(@display {label: "Connection Configuration"} ConnectionConfig twitterConfig) 
+    public isolated function init(ConnectionConfig twitterConfig, http:ClientConfiguration httpConfig = {}) 
                                   returns error? {
-        self.twitterClient = check new(TWITTER_API_URL, twitterConfig.clientConfig);
+        self.twitterClient = check new(TWITTER_API_URL, httpConfig);
         self.apiKey = twitterConfig.apiKey;
         self.apiSecret = twitterConfig.apiSecret;
         self.accessToken = twitterConfig.accessToken;
@@ -503,7 +504,6 @@ public isolated client class  Client {
 # + apiSecret - Api Secret
 # + accessToken - Access token
 # + accessTokenSecret - Access token secret
-# + clientConfig - Client configuration  
 @display{label: "Connection Config"} 
 public type ConnectionConfig record {
     @display {label: "API Key"}
@@ -514,5 +514,4 @@ public type ConnectionConfig record {
     string accessToken;
     @display {label: "Access Token Secret"}
     string accessTokenSecret;
-    http:ClientConfiguration clientConfig = {};
 };


### PR DESCRIPTION
## Purpose
- Add http client config as another parameter (To maintain the consistency across all connectors)
- Use same version for ballerina package and the java component
- Add gradle build output directory in .gitignore

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

