### PR TITLE
Fix build issue related to http listener

### DIFF
--- a/twitter/endpoint.bal
+++ b/twitter/endpoint.bal
@@ -119,13 +119,9 @@ public isolated client class  Client {
                                returns @tainted @display {label: "Tweet"} Tweet|error {
         http:Request request = new;
 
-        string tweetTextWithUrl = "";
         string in_reply_to_status_id = replyID.toString();
 
         string resourcePath = TWEET_ENDPOINT;
-        if (url is string) {
-            tweetTextWithUrl = tweetText + "\n" + url;
-        }
         string encodedStatus = check url:encode(tweetText, UTF_8);
         string urlParams = STATUS + encodedStatus + AMBERSAND;
         string encodedReplyValue = check url:encode(in_reply_to_status_id, UTF_8);
@@ -159,7 +155,6 @@ public isolated client class  Client {
                             returns @tainted @display {label: "Tweet"} Tweet|error {
         http:Request request = new;
 
-        string urlParams = "";
         string oauthString = "";
         string nonce = uuid:createType1AsString();
         [int, decimal] & readonly currentTime = time:utcNow();

--- a/twitter/modules/listener/http_service.bal
+++ b/twitter/modules/listener/http_service.bal
@@ -18,6 +18,7 @@ import ballerina/crypto;
 import ballerina/http;
 
 isolated service class HttpService {
+    *http:Service;
     private final HttpToTwitterAdaptor adaptor;
     private final EventDispatcher eventDispatcher;
     private final string apiKey;
@@ -39,7 +40,6 @@ isolated service class HttpService {
     isolated resource function post webhook/twitter(http:Caller caller, http:Request twitterRequest) returns 
                                            @tainted error? {                                        
         json payload = check twitterRequest.getJsonPayload();
-        map<json> mapPayload = <map<json>> payload;
         check caller->respond(http:STATUS_OK); 
         error? dispatchResult = self.eventDispatcher.dispatch(payload);
         if (dispatchResult is error) {
@@ -64,6 +64,7 @@ isolated service class HttpService {
             base64Result = output.toBase64();
             json response = {response_token: "sha256=" + base64Result};
             http:ListenerError? respond = caller->respond(<@untainted>(response));
+            return respond;
         } else {
             return error(TWITTER_ERROR, message = "Error in CRC token validation");
         }
@@ -83,8 +84,9 @@ isolated service class HttpService {
             base64Result = output.toBase64();
             json response = {response_token: "sha256=" + base64Result};
             http:ListenerError? respond = caller->respond(<@untainted>(response));
+            return respond;
         } else {
-                
+            return error(TWITTER_ERROR, message = "Error in CRC token validation");
         }
     }
 }

--- a/twitter/modules/listener/simple_http_service.bal
+++ b/twitter/modules/listener/simple_http_service.bal
@@ -14,4 +14,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public type SimpleHttpService service object {};
+public type SimpleHttpService distinct service object {};

--- a/twitter/modules/listener/utils.bal
+++ b/twitter/modules/listener/utils.bal
@@ -92,7 +92,10 @@ isolated function deleteWebHookURL(string apiKey, string apiSecret, string acces
         error err = error(TWITTER_ERROR, message = "Error occurred while encoding");
         return err;
     } else {
-        http:Response httpResponse = <http:Response> check httpClient->delete(resourcePath, request);
+        http:Response|error httpResponse = httpClient->delete(resourcePath, request);
+        if (httpResponse is http:Response) {
+           return null; 
+        }    
     }
 }
 
@@ -112,7 +115,10 @@ isolated function deleteSubscription(string apiKey, string apiSecret, string acc
         error err = error(TWITTER_ERROR, message = "Error occurred while encoding");
         return err;
     } else {
-        http:Response httpResponse = <http:Response> check httpClient->delete(resourcePath, request);
+        http:Response|error httpResponse = httpClient->delete(resourcePath, request);
+        if (httpResponse is http:Response) {
+           return null; 
+        }   
     }
 }
 


### PR DESCRIPTION
# Description
- Fix https://github.com/ballerina-platform/ballerina-extended-library/issues/157
- Make SimpleHttpService service type distinct
- Remove unused variable waring

All the standard library service definitions are now made `distinct`. Therefore, if you have created services without using the service declaration, you need to do the type inclusion explicitly as follows.

```
public service class MyHttpService {
    *http:Service;
   // some resources
}

public function main() returns error? {
    Listener l = check new;
    MyService myService = new;
    check l.attach(myService, "/foo");  
}

Or

http:Service myService = service object {
   // some resources
}
```

One line release note: 
- Make SimpleHttpService service type distinct 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Build & run the test cases using the following pack
https://github.com/ballerina-platform/ballerina-distribution/actions/runs/1478991785

**Test Configuration**:
* Ballerina Version: SLBeta4
* Operating System: Ubuntu 20.04
* Java SDK: 11

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 