### PR TITLE
Add operation to get tweets of specific handle

### DIFF
--- a/twitter/constants.bal
+++ b/twitter/constants.bal
@@ -29,6 +29,7 @@ const string FOLLOWINGS_ENDPOINT = "/1.1/friends/list.json";
 const string GET_USER_ENDPOINT = "/1.1/users/lookup.json";
 const string LIKE_TWEET_ENDPOINT = "/1.1/favorites/create.json";
 const string USER_TIMELINE_ENDPOINT = "/1.1/statuses/home_timeline.json";
+const string USER_HOME_TIMELINE_ENDPOINT = "/1.1/statuses/user_timeline.json";
 
 const string UTF_8 = "UTF-8";
 const string STATUS = "status=";

--- a/twitter/endpoint.bal
+++ b/twitter/endpoint.bal
@@ -403,6 +403,30 @@ public isolated client class  Client {
         return check handleStatusArrayResponse(httpResponse);
     }
 
+    # Get Tweets of a specific handle.
+    # 
+    # + handleName - Handle name of user 
+    # + return - If success, returns array of 'Tweet', else returns error
+    @display {label: "Get Tweets of specific Handle"} 
+    isolated remote function getUserTweets(@display {label: "Handle Name"} string handleName) 
+                                    returns @display {label: "Array Of Tweet"} Tweet[]|error {
+        http:Request request = new;
+
+        string resourcePath = USER_HOME_TIMELINE_ENDPOINT;
+        string encodedValue = check url:encode(handleName, UTF_8);
+        string urlParams = USERNAME + encodedValue + AMBERSAND;
+        string nonce = uuid:createType1AsString();
+        [int, decimal] & readonly currentTime = time:utcNow();
+        string timeStamp = currentTime[0].toString();
+        string oauthString = getOAuthParameters(self.apiKey, self.accessToken, nonce, timeStamp) + urlParams;
+
+        map<string> requestHeaders = check createRequestHeaderMap(request, GET, resourcePath, self.apiKey, self.apiSecret,
+            self.accessToken, self.accessTokenSecret, oauthString, nonce, timeStamp);
+        resourcePath = resourcePath + QUESTION_MARK + urlParams;
+        http:Response httpResponse = check self.twitterClient->get(resourcePath, requestHeaders);
+        return check handleStatusArrayResponse(httpResponse);
+    }
+
     # Get a user's last ten tweets.
     # 
     # + sinceId - Minimum tweet ID 

--- a/twitter/tests/test.bal
+++ b/twitter/tests/test.bal
@@ -126,10 +126,20 @@ function testGetUserTimeline() returns error? {
 @test:Config {
     dependsOn: [testGetUserTimeline], enable: true
 }
+function testGetUserTweets() returns error? {
+    log:printInfo("testGetUserTweets");
+    Tweet[] tweetResponse = check twitterClient->getUserTweets(screenName);
+    foreach Tweet tweet in tweetResponse {
+        log:printInfo(tweet.toString());
+    }
+}
+
+@test:Config {
+    dependsOn: [testGetUserTweets], enable: true
+}
 function testGetLast10Tweets() returns error? {
     log:printInfo("testGetLast10Tweets");
     Tweet[] tweetResponse = check twitterClient->getLast10Tweets(trimUser=true);
-    test:assertTrue(true, "Failed to call getLast10Tweets()");
     foreach Tweet tweet in tweetResponse {
         log:printInfo(tweet.toString());
     }


### PR DESCRIPTION
# Description
* Add new operation `getUserTweets` to get tweets in timeline with username/handle as parameter

**Test Configuration**:
* Ballerina Version: 2201.0.3
* Operating System: Ubuntu 20.04
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
