### PR TITLE
Bump bal version as 2201.7.0 in release workflows

### DIFF
--- a/.github/workflows/dev-stg-release.yml
+++ b/.github/workflows/dev-stg-release.yml
@@ -32,7 +32,7 @@ jobs:
               run: |
                   ./gradlew build
             - name: Ballerina Build
-              uses: ballerina-platform/ballerina-action/@2201.3.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                   args: pack ./twitter
               env:
@@ -40,7 +40,7 @@ jobs:
 
             - name: Push to Staging
               if: github.event.inputs.bal_central_environment == 'STAGE'
-              uses: ballerina-platform/ballerina-action/@2201.3.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                   args: push
               env:
@@ -50,7 +50,7 @@ jobs:
                   
             - name: Push to Dev
               if: github.event.inputs.bal_central_environment == 'DEV'
-              uses: ballerina-platform/ballerina-action/@2201.3.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                   args: push
               env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,14 @@ jobs:
               run: |
                   ./gradlew build
             - name: Ballerina Build
-              uses: ballerina-platform/ballerina-action/@2201.3.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                   args: pack ./twitter
               env:
                   JAVA_HOME: /usr/lib/jvm/default-jvm
 
             - name: Ballerina Push
-              uses: ballerina-platform/ballerina-action/@2201.3.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                   args: push
               env:


### PR DESCRIPTION
# Description
- Update bal version as 2201.7.0 in release workflows

## Related issue
- https://github.com/wso2-enterprise/choreo/issues/22438